### PR TITLE
Added config to run tests locally under 2.7, 3.3, 3.4 and 3.5 with code coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = nexmo
+parallel = True

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.coverage
+.tox/
+htmlcov/
+
 build/
 dist/
 nexmo.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,11 @@ setup(name='nexmo',
   license='MIT',
   packages=['nexmo'],
   platforms=['any'],
-  install_requires=['requests', 'PyJWT', 'cryptography'])
+  install_requires=['requests', 'PyJWT', 'cryptography'],
+  classifiers=[
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.5',
+  ])

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,7 @@ setup(name='nexmo',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
   ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=coverage-clean,py27,py35,coverage-report
+envlist=coverage-clean,py27,py33,py34,py35,coverage-report
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist=coverage-clean,py27,py35,coverage-report
+
+[testenv]
+setenv =
+    COVERAGE_FILE = .coverage.{envname}
+deps=
+    pytest==3.0.2
+    responses==0.5.1
+    pytest-cov==2.3.1
+    coverage==4.2
+commands=pytest --cov=nexmo --cov-report=term-missing {posargs:test_nexmo.py}
+
+[testenv:coverage-clean]
+setenv =
+    COVERAGE_FILE = .coverage
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:coverage-report]
+setenv =
+    COVERAGE_FILE = .coverage
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html


### PR DESCRIPTION
With these additions, you can run all the tests in test_nexmo.py by running `tox` on the command-line. (You need to install tox with `pip install tox` first.)

It's currently configured to run the tests under 2.7 and 3.3-3.5, but can easily be extend to run them under other versions.