### PR TITLE
Made `key` and `secret` optional params for JWT-only Clients.

### DIFF
--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -24,9 +24,9 @@ class AuthenticationError(ClientError):
 
 class Client():
   def __init__(self, **kwargs):
-    self.api_key = kwargs.get('key', None) or os.environ['NEXMO_API_KEY']
+    self.api_key = kwargs.get('key', None) or os.environ.get('NEXMO_API_KEY')
 
-    self.api_secret = kwargs.get('secret', None) or os.environ['NEXMO_API_SECRET']
+    self.api_secret = kwargs.get('secret', None) or os.environ.get('NEXMO_API_SECRET')
 
     self.signature_secret = kwargs.get('signature_secret', None) or os.environ.get('NEXMO_SIGNATURE_SECRET', None)
 

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -578,6 +578,19 @@ class NexmoClientTestCase(unittest.TestCase):
 
     self.assertEqual(self.client.signature(params), '6af838ef94998832dbfc29020b564830')
 
+  def test_client_doesnt_require_api_key(self):
+    try:
+      self.client = nexmo.Client(application_id='myid', private_key='abcde')
+    except Exception as e:
+      fail("Should be able to create a client without a key and secret")
+
+  @responses.activate
+  def test_client_can_make_application_requests_without_api_key(self):
+    self.stub(responses.POST, 'https://api.nexmo.com/v1/calls')
+
+    client = nexmo.Client(application_id='myid', private_key=self.private_key)
+    client.create_call("123455")
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This addresses #13 

Not sure this is really ready for merging. I'd like to add a test to see what happens when you attempt to, eg. send an SMS message without having key and secret set. I suspect the error will be a bit nasty and cryptic.