### PR TITLE
Support using file paths for private_key

### DIFF
--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -1,9 +1,15 @@
 __version__ = '1.4.0'
 
 
-import requests, os, warnings, hashlib, hmac, jwt, time, uuid
+import requests, os, warnings, hashlib, hmac, jwt, time, uuid, sys
 
 from platform import python_version
+
+
+if sys.version_info[0] == 3:
+  string_types = (str, bytes)
+else:
+  string_types = (unicode, str)
 
 
 class Error(Exception):
@@ -33,6 +39,9 @@ class Client():
     self.application_id = kwargs.get('application_id', None)
 
     self.private_key = kwargs.get('private_key', None)
+
+    if isinstance(self.private_key, string_types) and '\n' not in self.private_key:
+      self.private_key = open(self.private_key, 'rb').read()
 
     self.host = 'rest.nexmo.com'
 

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -41,7 +41,8 @@ class Client():
     self.private_key = kwargs.get('private_key', None)
 
     if isinstance(self.private_key, string_types) and '\n' not in self.private_key:
-      self.private_key = open(self.private_key, 'rb').read()
+      with open(self.private_key, 'rb') as key_file:
+        self.private_key = key_file.read()
 
     self.host = 'rest.nexmo.com'
 

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -658,7 +658,7 @@ class NexmoClientTestCase(unittest.TestCase):
     self.assertEqual(self.client.signature(params), '6af838ef94998832dbfc29020b564830')
 
   def test_client_doesnt_require_api_key(self):
-    client = nexmo.Client(application_id='myid', private_key='abcde')
+    client = nexmo.Client(application_id='myid', private_key='abc\nde')
     self.assertIsNotNone(client)
     self.assertIsNone(client.api_key)
     self.assertIsNone(client.api_secret)

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -572,6 +572,39 @@ class NexmoClientTestCase(unittest.TestCase):
     self.assertEqual(token['exp'], exp)
 
   @responses.activate
+  def test_authorization_with_private_key_path(self):
+    self.stub(responses.GET, 'https://api.nexmo.com/v1/calls/xx-xx-xx-xx')
+
+    private_key = 'test/private_key.txt'
+
+    self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, application_id=self.application_id, private_key=private_key)
+    self.client.get_call('xx-xx-xx-xx')
+
+    token = request_authorization().split()[1]
+
+    token = jwt.decode(token, self.public_key, algorithm='RS256')
+
+    self.assertEqual(token['application_id'], self.application_id)
+
+  @responses.activate
+  def test_authorization_with_private_key_object(self):
+    self.stub(responses.GET, 'https://api.nexmo.com/v1/calls/xx-xx-xx-xx')
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = serialization.load_pem_private_key(self.private_key.encode('utf-8'), password=None, backend=default_backend())
+
+    self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, application_id=self.application_id, private_key=private_key)
+    self.client.get_call('xx-xx-xx-xx')
+
+    token = request_authorization().split()[1]
+
+    token = jwt.decode(token, self.public_key, algorithm='RS256')
+
+    self.assertEqual(token['application_id'], self.application_id)
+
+  @responses.activate
   def test_authentication_error(self):
     responses.add(responses.POST, 'https://rest.nexmo.com/sms/json', status=401)
 


### PR DESCRIPTION
Fixes #12. Also adds a test to avoid breaking existing unspecified behaviour which is that keys can also be passed as RSAPrivateKey objects.