### PR TITLE
Add method for Number Insight Advanced API

### DIFF
--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -176,7 +176,12 @@ class Client():
   def get_basic_number_insight(self, params=None, **kwargs):
     return self.get(self.api_host, '/number/format/json', params or kwargs)
 
+  def get_standard_number_insight(self, params=None, **kwargs):
+    return self.get(self.api_host, '/ni/standard/json', params or kwargs)
+
   def get_number_insight(self, params=None, **kwargs):
+    warnings.warn('nexmo.Client#get_number_insight is deprecated (use #get_standard_number_insight instead)', DeprecationWarning, stacklevel=2)
+
     return self.get(self.api_host, '/number/lookup/json', params or kwargs)
 
   def get_advanced_number_insight(self, params=None, **kwargs):

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -179,6 +179,9 @@ class Client():
   def get_number_insight(self, params=None, **kwargs):
     return self.get(self.api_host, '/number/lookup/json', params or kwargs)
 
+  def get_advanced_number_insight(self, params=None, **kwargs):
+    return self.get(self.api_host, '/ni/advanced/json', params or kwargs)
+
   def request_number_insight(self, params=None, **kwargs):
     return self.post(self.host, '/ni/json', params or kwargs)
 

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -174,7 +174,7 @@ class Client():
     return self.post(self.api_host, '/verify/control/json', params or kwargs)
 
   def get_basic_number_insight(self, params=None, **kwargs):
-    return self.get(self.api_host, '/number/format/json', params or kwargs)
+    return self.get(self.api_host, '/ni/basic/json', params or kwargs)
 
   def get_standard_number_insight(self, params=None, **kwargs):
     return self.get(self.api_host, '/ni/standard/json', params or kwargs)

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -417,6 +417,14 @@ class NexmoClientTestCase(unittest.TestCase):
     self.assertIn('number=447525856424', request_query())
 
   @responses.activate
+  def test_get_standard_number_insight(self):
+    self.stub(responses.GET, 'https://api.nexmo.com/ni/standard/json')
+
+    self.assertIsInstance(self.client.get_standard_number_insight(number='447525856424'), dict)
+    self.assertEqual(request_user_agent(), self.user_agent)
+    self.assertIn('number=447525856424', request_query())
+
+  @responses.activate
   def test_get_number_insight(self):
     self.stub(responses.GET, 'https://api.nexmo.com/number/lookup/json')
 

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -425,6 +425,14 @@ class NexmoClientTestCase(unittest.TestCase):
     self.assertIn('number=447525856424', request_query())
 
   @responses.activate
+  def test_get_advanced_number_insight(self):
+    self.stub(responses.GET, 'https://api.nexmo.com/ni/advanced/json')
+
+    self.assertIsInstance(self.client.get_advanced_number_insight(number='447525856424'), dict)
+    self.assertEqual(request_user_agent(), self.user_agent)
+    self.assertIn('number=447525856424', request_query())
+
+  @responses.activate
   def test_request_number_insight(self):
     self.stub(responses.POST, 'https://rest.nexmo.com/ni/json')
 

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -410,7 +410,7 @@ class NexmoClientTestCase(unittest.TestCase):
 
   @responses.activate
   def test_get_basic_number_insight(self):
-    self.stub(responses.GET, 'https://api.nexmo.com/number/format/json')
+    self.stub(responses.GET, 'https://api.nexmo.com/ni/basic/json')
 
     self.assertIsInstance(self.client.get_basic_number_insight(number='447525856424'), dict)
     self.assertEqual(request_user_agent(), self.user_agent)


### PR DESCRIPTION
Fixes #15. Adds missing get_advanced_number_insight method, pointing to new endpoint. Adds get_standard_number_insight and deprecates get_number_insight for consistent naming.