### PR TITLE
Use assertRegex instead of assertRegexpMatches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install --quiet requests responses

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -250,7 +250,7 @@ class Client():
 
     params = dict(params, api_key=self.api_key, api_secret=self.api_secret)
 
-    return self.parse(host, requests.put(uri, data=params, headers=self.headers))
+    return self.parse(host, requests.put(uri, json=params, headers=self.headers))
 
   def delete(self, host, request_uri):
     uri = 'https://' + host + request_uri

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -468,7 +468,8 @@ class NexmoClientTestCase(unittest.TestCase):
 
     self.assertIsInstance(self.client.update_application('xx-xx-xx-xx', params), dict)
     self.assertEqual(request_user_agent(), self.user_agent)
-    self.assertIn('answer_url=https%3A%2F%2Fexample.com%2Fncco', request_body())
+    self.assertEqual(request_content_type(), 'application/json')
+    self.assertIn(b'"answer_url": "https://example.com/ncco"', request_body())
 
   @responses.activate
   def test_delete_application(self):

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -46,6 +46,9 @@ class NexmoClientTestCase(unittest.TestCase):
     self.user_agent = 'nexmo-python/{0}/{1}'.format(nexmo.__version__, platform.python_version())
     self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, application_id=self.application_id, private_key=self.private_key)
 
+    if not hasattr(self, 'assertRegex'):
+      self.assertRegex = self.assertRegexpMatches
+
     if not hasattr(self, 'assertRaisesRegex'):
       self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -498,7 +501,7 @@ class NexmoClientTestCase(unittest.TestCase):
 
     self.assertIsInstance(self.client.get_calls(), dict)
     self.assertEqual(request_user_agent(), self.user_agent)
-    self.assertRegexpMatches(request_authorization(), r'\ABearer ')
+    self.assertRegex(request_authorization(), r'\ABearer ')
 
   @responses.activate
   def test_get_call(self):
@@ -506,7 +509,7 @@ class NexmoClientTestCase(unittest.TestCase):
 
     self.assertIsInstance(self.client.get_call('xx-xx-xx-xx'), dict)
     self.assertEqual(request_user_agent(), self.user_agent)
-    self.assertRegexpMatches(request_authorization(), r'\ABearer ')
+    self.assertRegex(request_authorization(), r'\ABearer ')
 
   @responses.activate
   def test_update_call(self):


### PR DESCRIPTION
The assertRegexpMatches method was renamed to assertRegex in unittest 3.2