### PR TITLE
Added signature method implementation.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -62,6 +62,10 @@ In order to check signatures for incoming webhook requests, you'll also
 need to specify the ``signature_secret`` argument (or the
 ``NEXMO_SIGNATURE_SECRET`` environment variable).
 
+If the argument ``signature_method`` is omitted, it will default to the md5 hash
+algorithm. Otherwise, it will use the selected method as in md5, sha1, sha256 or
+sha512 with hmac.
+
 SMS API
 -------
 
@@ -252,6 +256,16 @@ Validate webhook signatures
     client = nexmo.Client(signature_secret='secret')
 
     if client.check_signature(request.query):
+      # valid signature
+    else:
+      # invalid signature
+
+
+    or by using signature method via POST:
+
+    client = nexmo.Client(signature_secret='secret', signature_method='sha256')
+
+    if client.check_signature(request.body.decode()):
       # valid signature
     else:
       # invalid signature

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -258,7 +258,12 @@ class Client():
             hasher = hashlib.md5()
 
         for key in sorted(params):
-            hasher.update('&{0}={1}'.format(key, params[key].replace('&', '_').replace('=', '_')).encode('utf-8'))
+            value = params[key]
+
+            if isinstance(value, str):
+                value = value.replace('&', '_').replace('=', '_')
+
+            hasher.update('&{0}={1}'.format(key, value).encode('utf-8'))
 
         if self.signature_method is None:
             hasher.update(self.signature_secret.encode())

--- a/nexmo/__init__.py
+++ b/nexmo/__init__.py
@@ -33,6 +33,16 @@ class Client():
         self.api_secret = kwargs.get('secret', None) or os.environ.get('NEXMO_API_SECRET', None)
 
         self.signature_secret = kwargs.get('signature_secret', None) or os.environ.get('NEXMO_SIGNATURE_SECRET', None)
+        self.signature_method = kwargs.get('signature_method', None) or os.environ.get('NEXMO_SIGNATURE_METHOD', None)
+
+        if self.signature_method == 'md5':
+            self.signature_method = hashlib.md5
+        elif self.signature_method == 'sha1':
+            self.signature_method = hashlib.sha1
+        elif self.signature_method == 'sha256':
+            self.signature_method = hashlib.sha256
+        elif self.signature_method == 'sha512':
+            self.signature_method = hashlib.sha512
 
         self.application_id = kwargs.get('application_id', None)
 
@@ -237,19 +247,23 @@ class Client():
     def check_signature(self, params):
         params = dict(params)
 
-        signature = params.pop('sig', '')
+        signature = params.pop('sig', '').lower()
 
         return hmac.compare_digest(signature, self.signature(params))
 
     def signature(self, params):
-        md5 = hashlib.md5()
+        if self.signature_method:
+            hasher = hmac.new(self.signature_secret.encode(), digestmod=self.signature_method)
+        else:
+            hasher = hashlib.md5()
 
         for key in sorted(params):
-            md5.update('&{0}={1}'.format(key, params[key]).encode('utf-8'))
+            hasher.update('&{0}={1}'.format(key, params[key].replace('&', '_').replace('=', '_')).encode('utf-8'))
 
-        md5.update(self.signature_secret.encode('utf-8'))
+        if self.signature_method is None:
+            hasher.update(self.signature_secret.encode())
 
-        return md5.hexdigest()
+        return hasher.hexdigest()
 
     def get(self, host, request_uri, params={}):
         uri = 'https://' + host + request_uri

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -40,6 +40,7 @@ class NexmoClientTestCase(unittest.TestCase):
     def setUp(self):
         self.api_key = 'nexmo-api-key'
         self.api_secret = 'nexmo-api-secret'
+        self.signature_secret = 'secret'
         self.application_id = 'nexmo-application-id'
         self.private_key = read_file('test/private_key.txt')
         self.public_key = read_file('test/public_key.txt')
@@ -671,16 +672,44 @@ class NexmoClientTestCase(unittest.TestCase):
     def test_check_signature(self):
         params = {'a': '1', 'b': '2', 'timestamp': '1461605396', 'sig': '6af838ef94998832dbfc29020b564830'}
 
-        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret='secret')
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret)
 
         self.assertTrue(self.client.check_signature(params))
 
     def test_signature(self):
         params = {'a': '1', 'b': '2', 'timestamp': '1461605396'}
 
-        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret='secret')
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret)
 
         self.assertEqual(self.client.signature(params), '6af838ef94998832dbfc29020b564830')
+
+    def test_signature_md5(self):
+        params = {'a': '1', 'b': '2', 'timestamp': '1461605396'}
+
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret, signature_method='md5')
+
+        self.assertEqual(self.client.signature(params), 'c15c21ced558c93a226c305f58f902f2')
+
+    def test_signature_sha1(self):
+        params = {'a': '1', 'b': '2', 'timestamp': '1461605396'}
+
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret, signature_method='sha1')
+
+        self.assertEqual(self.client.signature(params), '3e19a4e6880fdc2c1426bfd0587c98b9532f0210')
+
+    def test_signature_sha256(self):
+        params = {'a': '1', 'b': '2', 'timestamp': '1461605396'}
+
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret, signature_method='sha256')
+
+        self.assertEqual(self.client.signature(params), 'a321e824b9b816be7c3f28859a31749a098713d39f613c80d455bbaffae1cd24')
+
+    def test_signature_sha512(self):
+        params = {'a': '1', 'b': '2', 'timestamp': '1461605396'}
+
+        self.client = nexmo.Client(key=self.api_key, secret=self.api_secret, signature_secret=self.signature_secret, signature_method='sha512')
+
+        self.assertEqual(self.client.signature(params), '812a18f76680fa0fe1b8bd9ee1625466ceb1bd96242e4d050d2cfd9a7b40166c63ed26ec9702168781b6edcf1633db8ff95af9341701004eec3fcf9550572ee8')
 
     def test_client_doesnt_require_api_key(self):
         client = nexmo.Client(application_id='myid', private_key='abc\nde')


### PR DESCRIPTION
Implementation according to the Nexmo signing documentation:
https://docs.nexmo.com/messaging/signing-messages

Supporting MD5 hash and HMAC-SHA1/256/512.