### PR TITLE
Adding Advance NI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,18 @@ Docs: [https://docs.nexmo.com/number-insight/basic](https://docs.nexmo.com/numbe
 ### Standard Number Insight
 
 ```python
-client.get_number_insight(number='447700900000')
+client.get_standard_number_insight(number='447700900000')
 ```
 
 Docs: [https://docs.nexmo.com/number-insight/standard](https://docs.nexmo.com/number-insight/basic?utm_source=DEV_REL&utm_medium=github&utm_campaign=python-client-library?utm_source=DEV_REL&utm_medium=github&utm_campaign=python-client-library)
 
-<!-- when the switchover to new Number Insight is done, then we'll add Advance Insight... -->   
+### Advanced Number Insight
+
+```python
+client.get_advanced_number_insight(number='447700900000')
+```
+
+Docs: [https://docs.nexmo.com/number-insight/advanced](https://docs.nexmo.com/number-insight/advanced?utm_source=DEV_REL&utm_medium=github&utm_campaign=python-client-library?utm_source=DEV_REL&utm_medium=github&utm_campaign=python-client-library)
 
 ## Application API
 


### PR DESCRIPTION
As the current Advance NI endpoint is in the released version, the GitHub README ought to reflect that.

Also changed the standard endpoint function call to use the non-deprecated call.