### PR TITLE
send multiple sms with one connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 nexmo.egg-info/
+.idea

--- a/test_nexmo.py
+++ b/test_nexmo.py
@@ -69,6 +69,25 @@ class NexmoClientTestCase(unittest.TestCase):
         self.assertIn('text=Hey%21', request_body())
 
     @responses.activate
+    def test_send_many(self):
+        self.stub(responses.POST, 'https://rest.nexmo.com/sms/json')
+
+        params = {'from': 'Python', 'text': 'Hey!'}
+
+        results = self.client.send_many(['447525856424', '447525856425', '447525856426'], params)
+        self.assertIsInstance(results, list)
+        self.assertEqual(request_user_agent(), self.user_agent)
+        self.assertIn('from=Python', responses.calls[0].request.body)
+        self.assertIn('from=Python', responses.calls[1].request.body)
+        self.assertIn('from=Python', responses.calls[2].request.body)
+        self.assertIn('to=447525856424', responses.calls[0].request.body)
+        self.assertIn('to=447525856425', responses.calls[1].request.body)
+        self.assertIn('to=447525856426', responses.calls[2].request.body)
+        self.assertIn('text=Hey%21', responses.calls[0].request.body)
+        self.assertIn('text=Hey%21', responses.calls[1].request.body)
+        self.assertIn('text=Hey%21', responses.calls[2].request.body)
+
+    @responses.activate
     def test_get_balance(self):
         self.stub(responses.GET, 'https://rest.nexmo.com/account/get-balance')
 


### PR DESCRIPTION
According to Nexmo support, the way to send multiple sms in a "batch" is to keep the connection alive. (see https://help.nexmo.com/hc/en-us/articles/205065817-How-to-Send-Multiple-SMS-in-a-Single-API-Request)

I have added a `send_many` method which does just that using the `requests.Session()` object (see http://docs.python-requests.org/en/master/user/advanced/#keep-alive).

Not sure whether other people have this issue but it would be a nice feature to have.