### PR TITLE
Added minimum versions for dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,14 @@ setup(
     license="MIT",
     packages=["nexmo"],
     platforms=["any"],
-    install_requires=["requests>=2.4.2", "PyJWT[crypto]", "pytz"],
-    tests_require=["cryptography"],
+    install_requires=[
+        "requests>=2.4.2",
+        "PyJWT[crypto]>=1.6.4",
+        "pytz>=2018.5"
+    ],
+    tests_require=[
+        "cryptography>=2.3.1",
+    ],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
# Description

Installation of this package via pip could lead to outdated versions of dependent packages being used, which may result in unexpected or insecure behavior. `setup.py`'s `install_requires` has been updated to require minimum package versions.

This should close #38.

[Add versions for dependencies in setup.py](https://github.com/Nexmo/nexmo-python/issues/38)

## Type of change

Enhancement

## Where should the reviewer start?

All changes done in `setup.py`. The pinned versions should be verified.