### PR TITLE
Readme: Update the code example for client.send_audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Docs: [https://developer.nexmo.com/api/voice#updateCall](https://developer.nexmo
 ```python
 stream_url = 'https://nexmo-community.github.io/ncco-examples/assets/voice_api_audio_streaming.mp3'
 
-response = client.send_audio(uuid, stream_url=stream_url)
+response = client.send_audio(uuid, stream_url=[stream_url])
 ```
 
 Docs: [https://developer.nexmo.com/api/voice#startStream](https://developer.nexmo.com/api/voice#startStream#stream_put?utm_source=DEV_REL&utm_medium=github&utm_campaign=python-client-library)


### PR DESCRIPTION
I tried the code as is, and I got 400 error:
```
Client error: 400 b'{"type":400,"title":"Bad Request","invalid_parameters":[{"reason":"Invalid type parameter provided","name":"stream_url"}]}'
```
According to the docs, stream_url accepts an array of strings.
Changing the stream_url to a list works.