### PR TITLE
Add a check to install nexmo only in supported Python versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "PyJWT[crypto]>=1.6.4",
         "pytz>=2018.5"
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=[
         "cryptography>=2.3.1",
     ],


### PR DESCRIPTION
Adds `python_requires` in `setup.py` to avoid installing `nexmo-python` in python versions that are not supported.