### PR TITLE
Updates on dropping Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ client.api_host('myapi.nexmo.com') # rewrite the value of api_host
 ```
 
 ## Frequently Asked Questions
+### Dropping support for Python 2.7
+Back in 2014 when Guido van Rossum, Python's creator and principal author, made the announcement, January 1, 2020 seemed pretty far away. Python 2.7’s sunset has happened, after which there’ll be absolutely no more support from the core Python team. Many utilized projects pledge to drop Python 2 support in or before 2020. [(Official statement here)](https://www.python.org/doc/sunset-python-2/).
+
+Just because 2.7 isn’t going to be maintained past 2020 doesn’t mean your applications or libraries suddenly stop working but as of this moment we won't give official support for upcoming releases. Please read the official ["Porting Python 2 Code to Python 3" guide](https://docs.python.org/3/howto/pyporting.html). Please also read the [Python 3 Statement Practicalities](https://python3statement.org/practicalities/) for advice on sunsetting your Python 2 code.
 
 ### Supported APIs
 


### PR DESCRIPTION
- Adding why we are dropping support for Python 2.7 and official statements and information.